### PR TITLE
MADT table addition

### DIFF
--- a/hw/acpi/reduced.c
+++ b/hw/acpi/reduced.c
@@ -123,9 +123,13 @@ static void acpi_reduced_build(MachineState *ms, AcpiBuildTables *tables, AcpiCo
     dsdt = tables_blob->len;
     build_dsdt(tables_blob, tables->linker);
 
-    /* FADT MADT GTDT MCFG SPCR pointed to by RSDT */
+    /* FADT pointed to by RSDT */
     acpi_add_table(table_offsets, tables_blob);
     build_fadt_reduced(tables_blob, tables->linker, dsdt);
+
+    /* MADT pointed to by RSDT */
+    acpi_add_table(table_offsets, tables_blob);
+    mc->firmware_build_methods.acpi.madt(tables_blob, tables->linker, ms, conf);
 
     /* RSDT is pointed to by RSDP */
     rsdt = tables_blob->len;

--- a/hw/i386/virt/Makefile.objs
+++ b/hw/i386/virt/Makefile.objs
@@ -1,1 +1,1 @@
-obj-y += virt.o memory.o cmos.o
+obj-y += virt.o memory.o cmos.o acpi.o

--- a/hw/i386/virt/acpi.c
+++ b/hw/i386/virt/acpi.c
@@ -1,0 +1,123 @@
+/*
+ *
+ * Copyright (c) 2018 Intel Corporation
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 or later, as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/range.h"
+#include "qapi/error.h"
+#include "qom/cpu.h"
+
+#include "hw/hw.h"
+#include "hw/hotplug.h"
+
+#include "hw/i386/virt.h"
+#include "hw/i386/pc.h"
+
+#include "hw/acpi/acpi.h"
+#include "hw/acpi/cpu.h"
+#include "hw/acpi/acpi_dev_interface.h"
+
+typedef struct VirtAcpiState {
+    SysBusDevice parent_obj;
+} VirtAcpiState;
+
+#define TYPE_VIRT_ACPI "virt-acpi"
+#define VIRT_ACPI(obj) \
+    OBJECT_CHECK(VirtAcpiState, (obj), TYPE_VIRT_ACPI)
+
+static const VMStateDescription vmstate_acpi = {
+    .name = "virt_acpi",
+    .version_id = 1,
+    .minimum_version_id = 1,
+};
+
+static void virt_device_plug_cb(HotplugHandler *hotplug_dev,
+                                DeviceState *dev, Error **errp)
+{
+}
+
+static void virt_device_unplug_request_cb(HotplugHandler *hotplug_dev,
+                                          DeviceState *dev, Error **errp)
+{
+}
+
+static void virt_device_unplug_cb(HotplugHandler *hotplug_dev,
+                                  DeviceState *dev, Error **errp)
+{
+}
+
+static void virt_ospm_status(AcpiDeviceIf *adev, ACPIOSTInfoList ***list)
+{
+}
+
+static void virt_send_ged(AcpiDeviceIf *adev, AcpiEventStatusBits ev)
+{
+}
+
+static int virt_device_sysbus_init(SysBusDevice *dev)
+{
+    return 0;
+}
+
+DeviceState *virt_acpi_init(void)
+{
+    return sysbus_create_simple(TYPE_VIRT_ACPI, -1, NULL);
+}
+
+static Property virt_acpi_properties[] = {
+    DEFINE_PROP_END_OF_LIST(),
+};
+
+static void virt_acpi_class_init(ObjectClass *class, void *data)
+{
+    DeviceClass *dc = DEVICE_CLASS(class);
+    SysBusDeviceClass *sbc = SYS_BUS_DEVICE_CLASS(class);
+    HotplugHandlerClass *hc = HOTPLUG_HANDLER_CLASS(class);
+    AcpiDeviceIfClass *adevc = ACPI_DEVICE_IF_CLASS(class);
+
+    dc->desc = "ACPI";
+    dc->vmsd = &vmstate_acpi;
+    dc->props = virt_acpi_properties;
+
+    sbc->init = virt_device_sysbus_init;
+
+    hc->plug = virt_device_plug_cb;
+    hc->unplug_request = virt_device_unplug_request_cb;
+    hc->unplug = virt_device_unplug_cb;
+
+    adevc->ospm_status = virt_ospm_status;
+    adevc->send_event = virt_send_ged;
+    adevc->madt_cpu = pc_madt_cpu_entry;
+}
+
+static const TypeInfo virt_acpi_info = {
+    .name          = TYPE_VIRT_ACPI,
+    .parent        = TYPE_SYS_BUS_DEVICE,
+    .instance_size = sizeof(VirtAcpiState),
+    .class_init    = virt_acpi_class_init,
+    .interfaces = (InterfaceInfo[]) {
+        { TYPE_HOTPLUG_HANDLER },
+        { TYPE_ACPI_DEVICE_IF },
+        { }
+    }
+};
+
+static void virt_acpi_register_types(void)
+{
+    type_register_static(&virt_acpi_info);
+}
+
+type_init(virt_acpi_register_types)

--- a/include/hw/fw-build.h
+++ b/include/hw/fw-build.h
@@ -36,8 +36,9 @@ typedef struct FirmwareBuildMethods {
 
 typedef struct FirmwareBuildState {
     union {
-        /* ACPI state */
+        /* ACPI state and configuration */
         struct {
+            AcpiConfiguration *conf;
             AcpiBuildState *state;
         } acpi;
     };

--- a/include/hw/i386/virt.h
+++ b/include/hw/i386/virt.h
@@ -55,11 +55,15 @@ typedef struct {
 
     PCIBus *pci_bus;
 
+    /* ACPI device for hotplug and PM */
+    HotplugHandler *acpi_dev;
+
     /* RAM size */
     ram_addr_t below_4g_mem_size;
     ram_addr_t above_4g_mem_size;
 
     DeviceState *cmos;
+    DeviceState *acpi;
 } VirtMachineState;
 
 #define VIRT_MACHINE_FW "fw"

--- a/include/hw/i386/virt.h
+++ b/include/hw/i386/virt.h
@@ -77,4 +77,6 @@ MemoryRegion *virt_memory_init(VirtMachineState *vms);
 void virt_cmos_set(DeviceState *dev, uint8_t field, uint8_t value);
 DeviceState *virt_cmos_init(void);
 
+DeviceState *virt_acpi_init(void);
+
 #endif


### PR DESCRIPTION
The MADT ACPI table describes the platform interrupt controllers and the guest kernels builds the SMP information from it.

As the i386 MADT ACPI build routine depends on a system ACPI device, we first add a (for now) dummy ACPI device hanging of the system bus. Then we safely add the MADT tables to the set of tables we build for the virt i386 machine type.