### PR TITLE
acpi: reduced: Pass the right object to the update callback

### DIFF
--- a/hw/acpi/reduced.c
+++ b/hw/acpi/reduced.c
@@ -192,12 +192,12 @@ static void acpi_reduced_build_reset(void *build_opaque)
     build_state->patched = false;
 }
 
-static MemoryRegion *acpi_add_rom_blob(AcpiBuildState *build_state,
+static MemoryRegion *acpi_add_rom_blob(MachineState *ms,
                                        GArray *blob, const char *name,
                                        uint64_t max_size)
 {
     return rom_add_blob(name, blob->data, acpi_data_len(blob), max_size, -1,
-                        name, acpi_reduced_build_update, build_state, NULL, true);
+                        name, acpi_reduced_build_update, ms, NULL, true);
 }
 
 static const VMStateDescription vmstate_acpi_reduced_build = {
@@ -224,19 +224,19 @@ void acpi_reduced_setup(MachineState *machine, AcpiConfiguration *conf)
 
     if (conf->fw_cfg) {
         /* Now expose it all to Guest */
-        build_state->table_mr = acpi_add_rom_blob(build_state, tables.table_data,
+        build_state->table_mr = acpi_add_rom_blob(machine, tables.table_data,
                                                   ACPI_BUILD_TABLE_FILE,
                                                   ACPI_BUILD_TABLE_MAX_SIZE);
         assert(build_state->table_mr != NULL);
 
         build_state->linker_mr =
-            acpi_add_rom_blob(build_state, tables.linker->cmd_blob,
+            acpi_add_rom_blob(machine, tables.linker->cmd_blob,
                               "etc/table-loader", 0);
 
         fw_cfg_add_file(conf->fw_cfg, ACPI_BUILD_TPMLOG_FILE, tables.tcpalog->data,
                         acpi_data_len(tables.tcpalog));
 
-        build_state->rsdp_mr = acpi_add_rom_blob(build_state, tables.rsdp,
+        build_state->rsdp_mr = acpi_add_rom_blob(machine, tables.rsdp,
                                                  ACPI_BUILD_RSDP_FILE, 0);
     }
 


### PR DESCRIPTION
We are passing a AcpiBuildState object while the
acpi_reduced_build_update() routine takes a MachineState one as an
argument.
The joys of the C language.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>