### PR TITLE
hw: Use dynamic checking casts in callbacks

### DIFF
--- a/hw/acpi/reduced.c
+++ b/hw/acpi/reduced.c
@@ -157,7 +157,7 @@ static void acpi_ram_update(MemoryRegion *mr, GArray *data)
 
 static void acpi_reduced_build_update(void *build_opaque)
 {
-    MachineState *ms = build_opaque;
+    MachineState *ms = MACHINE(build_opaque);
     AcpiBuildState *build_state = ms->firmware_build_state.acpi.state;
     AcpiConfiguration *conf = ms->firmware_build_state.acpi.conf;
     AcpiBuildTables tables;
@@ -186,7 +186,7 @@ static void acpi_reduced_build_update(void *build_opaque)
 
 static void acpi_reduced_build_reset(void *build_opaque)
 {
-    MachineState *ms = build_opaque;
+    MachineState *ms = MACHINE(build_opaque);
     AcpiBuildState *build_state = ms->firmware_build_state.acpi.state;
 
     build_state->patched = false;

--- a/hw/char/sysbus_debugcon.c
+++ b/hw/char/sysbus_debugcon.c
@@ -52,7 +52,8 @@ typedef struct SysBusDebugConState {
 static void debugcon_ioport_write(void *opaque, hwaddr addr, uint64_t val,
                                   unsigned width)
 {
-    DebugconState *s = opaque;
+    SysBusDebugConState *d = SYS_DEBUGCON_DEVICE(opaque);
+    DebugconState *s = &d->state;
     unsigned char ch = val;
 
 #ifdef DEBUG_DEBUGCON
@@ -67,7 +68,8 @@ static void debugcon_ioport_write(void *opaque, hwaddr addr, uint64_t val,
 
 static uint64_t debugcon_ioport_read(void *opaque, hwaddr addr, unsigned width)
 {
-    DebugconState *s = opaque;
+    SysBusDebugConState *d = SYS_DEBUGCON_DEVICE(opaque);
+    DebugconState *s = &d->state;
 
 #ifdef DEBUG_DEBUGCON
     printf("debugcon: read addr=0x%04" HWADDR_PRIx "\n", addr);
@@ -106,7 +108,7 @@ static void debugcon_sysbus_realizefn(DeviceState *dev, Error **errp)
         error_propagate(errp, err);
         return;
     }
-    memory_region_init_io(&s->io, OBJECT(dev), &debugcon_ops, s,
+    memory_region_init_io(&s->io, OBJECT(dev), &debugcon_ops, sys,
                           TYPE_SYSBUS_DEBUGCON, 1);
     sysbus_add_io(d, sys->iobase, &s->io);
 }

--- a/hw/i386/virt/cmos.c
+++ b/hw/i386/virt/cmos.c
@@ -42,14 +42,14 @@ typedef struct VirtCmosState {
 static void virt_cmos_ioport_write(void *opaque, hwaddr addr, uint64_t val,
                                   unsigned width)
 {
-    VirtCmosState *s = opaque;
+    VirtCmosState *s = VIRT_CMOS_DEVICE(opaque);
 
     s->cmos_index = val & 0x7f;
 }
 
 static uint64_t virt_cmos_ioport_read(void *opaque, hwaddr addr, unsigned width)
 {
-    VirtCmosState *s = opaque;
+    VirtCmosState *s = VIRT_CMOS_DEVICE(opaque);
 
     return s->cmos_data[s->cmos_index];
 }


### PR DESCRIPTION
When casting from void * pointer in callbacks use the casts which
feature a dynamic type check to avoid issues with passing the wrong type
into data pointer for the callback.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>