### PR TITLE
Virt hotplug fixes

### DIFF
--- a/hw/acpi/cpu.c
+++ b/hw/acpi/cpu.c
@@ -567,9 +567,11 @@ void build_cpus_aml(Aml *table, MachineState *machine, CPUHotplugFeatures opts,
     aml_append(sb_scope, cpus_dev);
     aml_append(table, sb_scope);
 
-    method = aml_method(event_handler_method, 0, AML_NOTSERIALIZED);
-    aml_append(method, aml_call0("\\_SB.CPUS." CPU_SCAN_METHOD));
-    aml_append(table, method);
+    if (event_handler_method) {
+        method = aml_method(event_handler_method, 0, AML_NOTSERIALIZED);
+        aml_append(method, aml_call0("\\_SB.CPUS." CPU_SCAN_METHOD));
+        aml_append(table, method);
+    }
 
     g_free(cphp_res_path);
 }

--- a/hw/acpi/memory_hotplug.c
+++ b/hw/acpi/memory_hotplug.c
@@ -716,10 +716,12 @@ void build_memory_hotplug_aml(Aml *table, uint32_t nr_mem,
     }
     aml_append(table, dev_container);
 
-    method = aml_method(event_handler_method, 0, AML_NOTSERIALIZED);
-    aml_append(method,
-        aml_call0(MEMORY_DEVICES_CONTAINER "." MEMORY_SLOT_SCAN_METHOD));
-    aml_append(table, method);
+    if (event_handler_method) {
+        method = aml_method(event_handler_method, 0, AML_NOTSERIALIZED);
+        aml_append(method,
+                   aml_call0(MEMORY_DEVICES_CONTAINER "." MEMORY_SLOT_SCAN_METHOD));
+        aml_append(table, method);
+    }
 
     g_free(mhp_res_path);
 }

--- a/hw/acpi/reduced.c
+++ b/hw/acpi/reduced.c
@@ -65,7 +65,7 @@ static void acpi_dsdt_add_cpus(MachineState *ms, Aml *dsdt, Aml *scope, int smp_
     };
 
     build_cpus_aml(dsdt, ms, opts, conf->cpu_hotplug_io_base,
-                   "\\_SB.PCI1", GED_DEVICE);
+                   "\\_SB.PCI1", NULL);
 }
 
 static void acpi_dsdt_add_ged(Aml *scope, AcpiConfiguration *conf)

--- a/hw/i386/virt/virt.c
+++ b/hw/i386/virt/virt.c
@@ -529,9 +529,6 @@ static void virt_machine_device_pre_plug_cb(HotplugHandler *hotplug_dev,
 {
     if (object_dynamic_cast(OBJECT(dev), TYPE_CPU)) {
         virt_cpu_pre_plug(hotplug_dev, dev, errp);
-    } else {
-        error_setg(errp, "virt: device pre-plug for unsupported device"
-                   " type: %s", object_get_typename(OBJECT(dev)));
     }
 }
 


### PR DESCRIPTION
A couple of fixes for the virt hotplug implementation:

- Do not error out on unsupported devices pre-plug hooks, as not all devices require a pre-plug hook implementation
- Do not create the legacy AML hotplug event method when running HW reduced ACPI.