### PR TITLE
hw: i386: virt: Add NVDIMM support

### DIFF
--- a/hw/acpi/reduced.c
+++ b/hw/acpi/reduced.c
@@ -187,6 +187,11 @@ static void acpi_reduced_build(MachineState *ms, AcpiBuildTables *tables, AcpiCo
         acpi_add_table(table_offsets, tables_blob);
         mc->firmware_build_methods.acpi.mcfg(tables_blob, tables->linker, &mcfg);
     }
+    if (conf->acpi_nvdimm_state.is_enabled) {
+        nvdimm_build_acpi(table_offsets, tables_blob, tables->linker,
+                          &conf->acpi_nvdimm_state, ms->ram_slots);
+    }
+
     /* RSDT is pointed to by RSDP */
     xsdt = tables_blob->len;
     build_xsdt(tables_blob, tables->linker, table_offsets, NULL, NULL);
@@ -326,8 +331,7 @@ static Aml *ged_event_aml(GedEvent *event)
         return aml_call0("\\_SB.MHPC." MEMORY_SLOT_SCAN_METHOD);
     case GED_PCI_HOTPLUG:
     case GED_NVDIMM_HOTPLUG:
-        /* Not supported for now */
-        return NULL;
+        return aml_notify(aml_name("\\_SB.NVDR"), aml_int(0x80));
     default:
         break;
     }

--- a/hw/i386/virt/acpi.c
+++ b/hw/i386/virt/acpi.c
@@ -65,8 +65,12 @@ static void virt_device_plug_cb(HotplugHandler *hotplug_dev,
     if (object_dynamic_cast(OBJECT(dev), TYPE_CPU)) {
         acpi_cpu_plug_cb(hotplug_dev, &s->cpuhp_state, dev, errp);
     } else if (object_dynamic_cast(OBJECT(dev), TYPE_PC_DIMM)) {
-        acpi_memory_plug_cb(hotplug_dev, &s->memhp_state,
-                            dev, errp);
+        if (object_dynamic_cast(OBJECT(dev), TYPE_NVDIMM)) {
+            nvdimm_acpi_plug_cb(hotplug_dev, dev);
+        } else {
+            acpi_memory_plug_cb(hotplug_dev, &s->memhp_state,
+                                dev, errp);
+        }
     }  else {
         error_setg(errp, "virt: device plug request for unsupported device"
                    " type: %s", object_get_typename(OBJECT(dev)));
@@ -117,6 +121,8 @@ static void virt_send_ged(AcpiDeviceIf *adev, AcpiEventStatusBits ev)
     } else if (ev & ACPI_MEMORY_HOTPLUG_STATUS) {
         /* We inject the memory hotplug interrupt */
         qemu_irq_pulse(s->gsi[VIRT_GED_MEMORY_HOTPLUG_IRQ]);
+    } else if (ev & ACPI_NVDIMM_HOTPLUG_STATUS) {
+        qemu_irq_pulse(s->gsi[VIRT_GED_NVDIMM_HOTPLUG_IRQ]);
     }
 }
 

--- a/hw/i386/virt/virt.c
+++ b/hw/i386/virt/virt.c
@@ -100,7 +100,8 @@ static void acpi_conf_virt_init(MachineState *machine, AcpiConfiguration *conf)
     conf->acpi_dev = vms->acpi_dev;
     conf->cpu_hotplug_io_base = VIRT_CPU_HOTPLUG_IO_BASE;
     conf->hotplug_memory = vms->hotplug_memory;
-
+    conf->acpi_nvdimm_state = vms->acpi_nvdimm_state;
+ 
     /* GED events */
     GedEvent events[] = {
         {
@@ -110,6 +111,10 @@ static void acpi_conf_virt_init(MachineState *machine, AcpiConfiguration *conf)
         {
             .irq   = VIRT_GED_MEMORY_HOTPLUG_IRQ,
             .event = GED_MEMORY_HOTPLUG,
+        },
+        {
+            .irq   = VIRT_GED_NVDIMM_HOTPLUG_IRQ,
+            .event = GED_NVDIMM_HOTPLUG,
         },
     };
 
@@ -228,6 +233,11 @@ static void virt_machine_state_init(MachineState *machine)
                             val, sizeof(*val));
         }
 
+        if (vms->acpi_nvdimm_state.is_enabled) {
+            nvdimm_init_acpi_state(&vms->acpi_nvdimm_state, get_system_io(),
+                                   fw_cfg, OBJECT(vms));
+        }
+
         vms->fw_cfg = fw_cfg;
         acpi_conf_virt_init(MACHINE(vms), vms->acpi_configuration);
 
@@ -235,6 +245,11 @@ static void virt_machine_state_init(MachineState *machine)
             load_linux_bzimage(MACHINE(vms), vms->acpi_configuration, fw_cfg);
         }
     } else {
+        if (vms->acpi_nvdimm_state.is_enabled) {
+            nvdimm_init_acpi_state(&vms->acpi_nvdimm_state, get_system_io(),
+                                   NULL, OBJECT(vms));
+        }
+
         acpi_conf_virt_init(MACHINE(vms), vms->acpi_configuration);
 
         if (linux_boot) {
@@ -257,11 +272,28 @@ static void virt_machine_set_fw(Object *obj, bool value, Error **errp)
     vms->fw = value;
 }
 
+static bool virt_machine_get_nvdimm(Object *obj, Error **errp)
+{
+    VirtMachineState *vms = VIRT_MACHINE(obj);
+
+    return vms->acpi_nvdimm_state.is_enabled;
+}
+
+static void virt_machine_set_nvdimm(Object *obj, bool value, Error **errp)
+{
+    VirtMachineState *vms = VIRT_MACHINE(obj);
+
+    vms->acpi_nvdimm_state.is_enabled = value;
+}
+
 static void virt_machine_instance_init(Object *obj)
 {
     VirtMachineState *vms = VIRT_MACHINE(obj);
 
     vms->fw = true;
+
+    /* Disable NVDIMM by default */
+    vms->acpi_nvdimm_state.is_enabled = false;
 }
 
 static void virt_machine_reset(void)
@@ -317,6 +349,11 @@ static void virt_class_init(ObjectClass *oc, void *data)
     object_class_property_add_bool(oc, VIRT_MACHINE_FW,
                                    virt_machine_get_fw, virt_machine_set_fw, &error_abort);
 
+    /* NVDIMM property */
+    object_class_property_add_bool(oc, VIRT_MACHINE_NVDIMM,
+                                   virt_machine_get_nvdimm,
+                                   virt_machine_set_nvdimm,
+                                   &error_abort);
 }
 
 static const TypeInfo virt_machine_info = {
@@ -553,6 +590,7 @@ static void virt_dimm_plug(HotplugHandler *hotplug_dev,
     PCDIMMDeviceClass *ddc = PC_DIMM_GET_CLASS(dimm);
     MemoryRegion *mr;
     uint64_t align = TARGET_PAGE_SIZE;
+    bool is_nvdimm = object_dynamic_cast(OBJECT(dev), TYPE_NVDIMM);
 
     assert(vms->acpi);
     mr = ddc->get_memory_region(dimm, &local_err);
@@ -564,10 +602,19 @@ static void virt_dimm_plug(HotplugHandler *hotplug_dev,
         align = memory_region_get_alignment(mr);
     }
 
-    pc_dimm_memory_plug(dev, &vms->hotplug_memory, mr, align, &local_err);
+    if (is_nvdimm && !vms->acpi_nvdimm_state.is_enabled) {
+        error_setg(&local_err,
+                   "nvdimm is not enabled: missing 'nvdimm' in '-M'");
+        goto out;
+    }
 
+    pc_dimm_memory_plug(dev, &vms->hotplug_memory, mr, align, &local_err);
     if (local_err) {
         goto out;
+    }
+
+    if (is_nvdimm) {
+        nvdimm_plug(&vms->acpi_nvdimm_state);
     }
 
     hhc = HOTPLUG_HANDLER_GET_CLASS(vms->acpi);

--- a/include/hw/i386/virt.h
+++ b/include/hw/i386/virt.h
@@ -63,13 +63,16 @@ typedef struct {
 
     MemoryHotplugState hotplug_memory;
 
+    AcpiNVDIMMState acpi_nvdimm_state;
+
     /* RAM size */
     ram_addr_t below_4g_mem_size, above_4g_mem_size;
 
     DeviceState *acpi;
 } VirtMachineState;
 
-#define VIRT_MACHINE_FW "fw"
+#define VIRT_MACHINE_FW     "fw"
+#define VIRT_MACHINE_NVDIMM "nvdimm"
 
 #define TYPE_VIRT_MACHINE   MACHINE_TYPE_NAME("virt")
 #define VIRT_MACHINE(obj) \

--- a/tools/CI/start_qemu.sh
+++ b/tools/CI/start_qemu.sh
@@ -260,7 +260,7 @@ case "$PLATFORM" in
        ;;
     x86_64_virt)
        machine='virt'
-       accel='kvm,kernel_irqchip'
+       accel='kvm,kernel_irqchip,nvdimm'
        SIMPLE_LAUNCH="true"
        ;;
     aarch64)


### PR DESCRIPTION
This commit introduces the NVDIMM support. It includes the NVDIMM
hotplug since the way NVDIMM is added is always through hotplug,
even when an NVDIMM device is defined from the Qemu command line.

First, this code builds a new SSDT table with the NVDR device
described inside as a specific platform device.

Then it updates the GED method of the DSDT table, by defining a new
Notify() method to notify the guest OS driver that something changed
regarding the NVDIMM devices.

All of this happen if NVDIMM is enabled at the machine level.

The last thing this patch does is to send an interrupt to the guest
kernel everytime a new NVDIMM device is plugged. This triggers the
GED method defined in the DSDT.

Fixes #44