### PR TITLE
virt: acpi: fixed one cpu acpi bug

### DIFF
--- a/hw/acpi/reduced.c
+++ b/hw/acpi/reduced.c
@@ -60,15 +60,6 @@ static void acpi_dsdt_add_memory_hotplug(MachineState *ms, Aml *dsdt)
 
 static void acpi_dsdt_add_cpus(MachineState *ms, Aml *dsdt, Aml *scope, int smp_cpus, AcpiConfiguration *conf)
 {
-    uint16_t i;
-
-    for (i = 0; i < smp_cpus; i++) {
-        Aml *dev = aml_device("C%.03X", i);
-        aml_append(dev, aml_name_decl("_HID", aml_string("ACPI0007")));
-        aml_append(dev, aml_name_decl("_UID", aml_int(i)));
-        aml_append(scope, dev);
-    }
-
     CPUHotplugFeatures opts = {
         .apci_1_compatible = false,
         .has_legacy_cphp = false,


### PR DESCRIPTION
From the guest kernel log, we can find below error log:
acpi ACPI0007:08: BIOS reported wrong ACPI id 0 for the processor
acpi ACPI0007:09: BIOS reported wrong ACPI id 1 for the processor

This issue is caused by re-define ACPI0007 aml table. Those changes
do not impact cpu hotplug.

Signed-off-by: Yang Zhong <yang.zhong@intel.com>