### PR TITLE
i386: virt: Enforce DIMM memory restrictions

### DIFF
--- a/hw/i386/virt/virt.c
+++ b/hw/i386/virt/virt.c
@@ -596,6 +596,8 @@ out:
     error_propagate(errp, local_err);
 }
 
+// 128MiB requirement for alignment on Linux
+#define LINUX_SPARSE_MEMORY_ALIGNMENT 0x8000000
 
 static void virt_dimm_plug(HotplugHandler *hotplug_dev,
                          DeviceState *dev, Error **errp)
@@ -608,6 +610,7 @@ static void virt_dimm_plug(HotplugHandler *hotplug_dev,
     MemoryRegion *mr;
     uint64_t align = TARGET_PAGE_SIZE;
     bool is_nvdimm = object_dynamic_cast(OBJECT(dev), TYPE_NVDIMM);
+    uint64_t free_addr;
 
     assert(vms->acpi);
     mr = ddc->get_memory_region(dimm, &local_err);
@@ -624,6 +627,22 @@ static void virt_dimm_plug(HotplugHandler *hotplug_dev,
                    "nvdimm is not enabled: missing 'nvdimm' in '-M'");
         goto out;
     }
+
+    // Ensure that the start address is always aligned to the 128MiB boundary
+    // and for non-NVDIMM devices ensure that the size is a multiple of 128MiB
+    // otherwise the Linux kernel will reject
+    if (!is_nvdimm) {
+        align = LINUX_SPARSE_MEMORY_ALIGNMENT;
+    }
+
+    free_addr = pc_dimm_get_free_addr(vms->hotplug_memory.base,
+                                      memory_region_size(&vms->hotplug_memory.mr),
+                                      NULL, align, memory_region_size(mr), &local_err);
+    if (local_err) {
+        goto out;
+    }
+
+    dimm->addr = ROUND_UP(free_addr, LINUX_SPARSE_MEMORY_ALIGNMENT);
 
     pc_dimm_memory_plug(dev, &vms->hotplug_memory, mr, align, &local_err);
     if (local_err) {


### PR DESCRIPTION
When hotplugging memory the Linux kernel will reject memory that is not
correctly aligned to 128MiB and expects the size to be a multiple of the
same. However for NVDIMM no such restrictions apply but in order to be
able to combine the hotplugging of NVDIMMs with memory hotplug it is
necessary to ensure that all NVDIMM start addresses are aligned as
above.

We achieve that by identifying the next available address for the memory
and rounding that to 128MiB and using that as the allocation hint.
Further if this is not an NVDIMM being plugged we also use the existing
alignment mechanism to enforce the size constraint too.

This was tested by adding a small NVDIMM and then hotplugging memory.
The appropriate output from /proc/iomem looks like this:

fee00000-fee00fff : Local APIC
100000000-10000bfff : Persistent Memory
  100000000-10000bfff : namespace0.0
108000000-147ffffff : System RAM

Signed-off-by: Rob Bradford <robert.bradford@intel.com>