### PR TITLE
acpi: memory-hotplug: fixed dsdt error in dsl file

### DIFF
--- a/hw/acpi/memory_hotplug.c
+++ b/hw/acpi/memory_hotplug.c
@@ -687,15 +687,15 @@ void build_memory_hotplug_aml(Aml *table, uint32_t nr_mem,
 
             method = aml_method("_OST", 3, AML_NOTSERIALIZED);
             s = MEMORY_SLOT_OST_METHOD;
-            aml_append(method, aml_return(aml_call4(
-                s, aml_name("_UID"), aml_arg(0), aml_arg(1), aml_arg(2)
-            )));
+            aml_append(method,
+                       aml_call4(s, aml_name("_UID"), aml_arg(0),
+                                 aml_arg(1), aml_arg(2)));
             aml_append(dev, method);
 
             method = aml_method("_EJ0", 1, AML_NOTSERIALIZED);
             s = MEMORY_SLOT_EJECT_METHOD;
-            aml_append(method, aml_return(aml_call2(
-                       s, aml_name("_UID"), aml_arg(0))));
+            aml_append(method,
+                       aml_call2(s, aml_name("_UID"), aml_arg(0)));
             aml_append(dev, method);
 
             aml_append(dev_container, dev);


### PR DESCRIPTION
@sameo @rbradford @mcastelino

Please review below bug  fix for #51 , after this patch, the "iasl -tc dsdt.dsl" command as below
dsdt.dsl    140:             CreateDWordField (MR64, \_SB.MHPC.MCRS._Y00._MIN, MINL)  // _MIN: Minimum Base Address
Warning  3128 -                              ResourceTag larger than Field ^  (Size mismatch, Tag: 64 bits, Field: 32 bits)

dsdt.dsl    142:             CreateDWordField (MR64, \_SB.MHPC.MCRS._Y00._LEN, LENL)  // _LEN: Length
Warning  3128 -                              ResourceTag larger than Field ^  (Size mismatch, Tag: 64 bits, Field: 32 bits)

dsdt.dsl    144:             CreateDWordField (MR64, \_SB.MHPC.MCRS._Y00._MAX, MAXL)  // _MAX: Maximum Base Address
Warning  3128 -                              ResourceTag larger than Field ^  (Size mismatch, Tag: 64 bits, Field: 32 bits)

dsdt.dsl    198:         Method (MOST, 4, NotSerialized)
Remark   2146 -                    ^ Method Argument is never used (Arg3)

dsdt.dsl    207:         Method (MEJ0, 2, NotSerialized)
Remark   2146 -                    ^ Method Argument is never used (Arg1)

dsdt.dsl    454:             Method (COST, 4, Serialized)
Remark   2146 -                        ^ Method Argument is never used (Arg3)

ASL Input:     dsdt.dsl - 829 lines, 27450 bytes, 348 keywords
AML Output:    dsdt.aml - 3474 bytes, 159 named objects, 189 executable opcodes
Hex Dump:      dsdt.hex - 33013 bytes

Compilation complete. 0 Errors, 3 Warnings, 3 Remarks, 42 Optimizations

I also tried to replace CreateDWordField  with  CreateQWordField to remove this warning, but the memory plug can not work. So i leave this kind warning here.

With this patch, the memory hotplug still work well. thanks!  