### PR TITLE
hw/acpi: Fix PCI host bridge ACPI initialisation

### DIFF
--- a/hw/acpi/aml-build.c
+++ b/hw/acpi/aml-build.c
@@ -2316,7 +2316,7 @@ Aml *build_pci_host_bridge(Aml *table, AcpiPciBus *pci_host)
 
 void acpi_dsdt_add_pci_bus(Aml *table, AcpiPciBus *pci_host)
 {
-    Aml *dev, *sb_scope;
+    Aml *dev, *sb_scope, *pci_scope;
 
     sb_scope = aml_scope("_SB");
     dev = aml_device("PCI0");
@@ -2330,7 +2330,8 @@ void acpi_dsdt_add_pci_bus(Aml *table, AcpiPciBus *pci_host)
     aml_append(sb_scope, dev);
     aml_append(table, sb_scope);
 
-    build_pci_host_bridge(table, pci_host);
+    pci_scope = build_pci_host_bridge(table, pci_host);
+    aml_append(table, pci_scope);
 }
 
 #define HOLE_640K_START  (640 * 1024)


### PR DESCRIPTION
The function build_pci_host_bridge() formerly added the newly created scope to
the table however as it now returns the scope instead it is the caller's
responsibility to add to the table.

This fixes the error message on bootup:

[    0.007492] acpi PNP0A08:00: [Firmware Bug]: no secondary bus range in _CRS

And prevented the BARs from being allocated for the PCI devices on the bus

Signed-off-by: Rob Bradford <robert.bradford@intel.com>