### PR TITLE
hw/i386/virt: Initialize AcpiConfiguration's below_4g_mem_size

### DIFF
--- a/hw/i386/virt/memory.c
+++ b/hw/i386/virt/memory.c
@@ -42,6 +42,7 @@ MemoryRegion *virt_memory_init(VirtMachineState *vms)
     }
 
     vms->above_4g_mem_size = highmem_size;
+    vms->below_4g_mem_size = lowmem_size;
 
     memory_region_allocate_system_memory(ram, NULL, "virt.ram",
                                          machine->ram_size);

--- a/hw/i386/virt/virt.c
+++ b/hw/i386/virt/virt.c
@@ -100,6 +100,7 @@ static void acpi_conf_virt_init(MachineState *machine)
     conf->numa_nodes = vms->numa_nodes;
     conf->node_mem = vms->node_mem;
     conf->apic_id_limit = vms->apic_id_limit;
+    conf->below_4g_mem_size = vms->below_4g_mem_size;
     conf->acpi_dev = vms->acpi_dev;
     conf->cpu_hotplug_io_base = VIRT_CPU_HOTPLUG_IO_BASE;
     conf->acpi_nvdimm_state = vms->acpi_nvdimm_state;

--- a/include/hw/i386/virt.h
+++ b/include/hw/i386/virt.h
@@ -62,6 +62,7 @@ typedef struct {
 
     /* RAM size */
     ram_addr_t above_4g_mem_size;
+    ram_addr_t below_4g_mem_size;
 
     DeviceState *acpi;
 } VirtMachineState;


### PR DESCRIPTION
This struct member is read by the ACPI table (SRAT) population code in order to
publish the PCI hole in the NUMA configuration.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>