### PR TITLE
dsdt: simplify PCI0 path

### DIFF
--- a/hw/acpi/aml-build.c
+++ b/hw/acpi/aml-build.c
@@ -2314,12 +2314,11 @@ Aml *build_pci_host_bridge(Aml *table, AcpiPciBus *pci_host)
     return scope;
 }
 
-void acpi_dsdt_add_pci_bus(Aml *table, AcpiPciBus *pci_host)
+void acpi_dsdt_add_pci_bus(Aml *dsdt, AcpiPciBus *pci_host)
 {
-    Aml *dev, *sb_scope, *pci_scope;
+    Aml *dev, *pci_scope;
 
-    sb_scope = aml_scope("_SB");
-    dev = aml_device("PCI0");
+    dev = aml_device("\\_SB.PCI0");
     aml_append(dev, aml_name_decl("_HID", aml_eisaid("PNP0A08")));
     aml_append(dev, aml_name_decl("_CID", aml_eisaid("PNP0A03")));
     aml_append(dev, aml_name_decl("_ADR", aml_int(0)));
@@ -2327,11 +2326,10 @@ void acpi_dsdt_add_pci_bus(Aml *table, AcpiPciBus *pci_host)
     aml_append(dev, aml_name_decl("SUPP", aml_int(0)));
     aml_append(dev, aml_name_decl("CTRL", aml_int(0)));
     aml_append(dev, build_osc_method(0x1F));
-    aml_append(sb_scope, dev);
-    aml_append(table, sb_scope);
+    aml_append(dsdt, dev);
 
-    pci_scope = build_pci_host_bridge(table, pci_host);
-    aml_append(table, pci_scope);
+    pci_scope = build_pci_host_bridge(dsdt, pci_host);
+    aml_append(dsdt, pci_scope);
 }
 
 #define HOLE_640K_START  (640 * 1024)

--- a/hw/acpi/aml-build.c
+++ b/hw/acpi/aml-build.c
@@ -2316,7 +2316,7 @@ Aml *build_pci_host_bridge(Aml *table, AcpiPciBus *pci_host)
 
 void acpi_dsdt_add_pci_bus(Aml *table, AcpiPciBus *pci_host)
 {
-    Aml *dev, *sb_scope;
+    Aml *dev, *sb_scope, *pci_scope;
 
     sb_scope = aml_scope("_SB");
     dev = aml_device("PCI0");
@@ -2330,7 +2330,8 @@ void acpi_dsdt_add_pci_bus(Aml *table, AcpiPciBus *pci_host)
     aml_append(sb_scope, dev);
     aml_append(table, sb_scope);
 
-    build_pci_host_bridge(table, pci_host);
+    pci_scope = build_pci_host_bridge(table, pci_host);
+    aml_append(table, pci_scope);
 }
 
 #define HOLE_640K_START  (640 * 1024)

--- a/hw/acpi/reduced.c
+++ b/hw/acpi/reduced.c
@@ -99,9 +99,9 @@ static void build_dsdt(MachineState *ms, GArray *table_data, BIOSLinker *linker,
     acpi_data_push(dsdt->buf, sizeof(AcpiTableHeader));
 
     scope = aml_scope("\\_SB");
+    acpi_dsdt_add_pci_bus(dsdt, pci_host);
     acpi_dsdt_add_memory_hotplug(ms, dsdt);
     acpi_dsdt_add_cpus(ms, dsdt, scope, smp_cpus, conf);
-    acpi_dsdt_add_pci_bus(scope, pci_host);
     acpi_dsdt_add_ged(scope, conf);
     acpi_dsdt_add_sleep_state(scope);
 

--- a/include/hw/acpi/aml-build.h
+++ b/include/hw/acpi/aml-build.h
@@ -420,7 +420,7 @@ Aml *build_osc_method(uint32_t value);
 void acpi_build_mcfg(GArray *table_data, BIOSLinker *linker, AcpiMcfgInfo *info);
 Aml *build_gsi_link_dev(const char *name, uint8_t uid, uint8_t gsi);
 Aml *build_prt(bool is_pci0_prt);
-void acpi_dsdt_add_pci_bus(Aml *table, AcpiPciBus *pci_host);
+void acpi_dsdt_add_pci_bus(Aml *dsdt, AcpiPciBus *pci_host);
 Aml *build_pci_host_bridge(Aml *table, AcpiPciBus *pci_host);
 void crs_range_set_init(CrsRangeSet *range_set);
 Aml *build_crs(PCIHostState *host, CrsRangeSet *range_set);


### PR DESCRIPTION
@mcastelino @sameo  @rbradford @sboeuf
 
The first patch is based on #66 
The second patch simplifies the PCI0 device path from \_SB._SB.PCI0 to \_SB.PCI0