### PR TITLE
hw: acpi: Don't put CPU and memory under PCI1 namespace

### DIFF
--- a/hw/acpi/reduced.c
+++ b/hw/acpi/reduced.c
@@ -55,7 +55,7 @@ static void acpi_dsdt_add_memory_hotplug(MachineState *ms, Aml *dsdt)
 {
     uint32_t nr_mem = ms->ram_slots;
 
-    build_memory_hotplug_aml(dsdt, nr_mem, "\\_SB.PCI1", NULL);
+    build_memory_hotplug_aml(dsdt, nr_mem, "\\_SB", NULL);
 }
 
 static void acpi_dsdt_add_cpus(MachineState *ms, Aml *dsdt, Aml *scope, int smp_cpus, AcpiConfiguration *conf)
@@ -66,7 +66,7 @@ static void acpi_dsdt_add_cpus(MachineState *ms, Aml *dsdt, Aml *scope, int smp_
     };
 
     build_cpus_aml(dsdt, ms, opts, conf->cpu_hotplug_io_base,
-                   "\\_SB.PCI1", NULL);
+                   "\\_SB", NULL);
 }
 
 static void acpi_dsdt_add_ged(Aml *scope, AcpiConfiguration *conf)


### PR DESCRIPTION
There is no reason to put both CPU and memory hotplug under PCI1
namespace, but more than that, it's causing some trouble with PCI
experimentations when we're trying to allocate more than one PCI
bus.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>