### PR TITLE
nats: Bump Clear version to 24950

### DIFF
--- a/tools/CI/nats/nemu_test.go
+++ b/tools/CI/nats/nemu_test.go
@@ -317,7 +317,7 @@ const (
 )
 
 const (
-	clearDiskImage  = "clear-24740-cloud.img"
+	clearDiskImage  = "clear-24950-cloud.img"
 	ubuntuDiskImage = "xenial-server-cloudimg-amd64-uefi1.img"
 )
 

--- a/tools/CI/run_nats.sh
+++ b/tools/CI/run_nats.sh
@@ -2,7 +2,7 @@
 set -x
 
 GO_VERSION="1.10.3"
-CLEAR_VERSION=24740
+CLEAR_VERSION=24950
 CLEAR_IMAGE=clear-$CLEAR_VERSION-cloud.img
 UBUNTU_IMAGE=xenial-server-cloudimg-amd64-uefi1.img
 WORKLOADS_DIR="$HOME/workloads"

--- a/tools/CI/run_nats.sh
+++ b/tools/CI/run_nats.sh
@@ -56,7 +56,7 @@ popd
 sudo adduser $USER kvm
 pushd $SRCDIR/tools/CI/nats
 newgrp kvm << EOF
-go test -v -timeout 20m -parallel $((`nproc`/2)) || exit $?
+go test -v -timeout 20m -parallel \$((`nproc`/2)) || exit \$?
 EOF
 RES=$?
 popd


### PR DESCRIPTION
Update to the latest Clear Linux release.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>