### PR TITLE
tools: Ensure that the exit code is propagated

### DIFF
--- a/tools/CI/run_nats.sh
+++ b/tools/CI/run_nats.sh
@@ -56,7 +56,7 @@ popd
 sudo adduser $USER kvm
 pushd $SRCDIR/tools/CI/nats
 newgrp kvm << EOF
-go test -v -timeout 20m -parallel $((`nproc`/2)) || exit $?
+go test -v -timeout 20m -parallel \$((`nproc`/2)) || exit \$?
 EOF
 RES=$?
 popd


### PR DESCRIPTION
The commands run as newgrp need to have their $s escaped otherwise they will be
substituted too early.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>