### PR TITLE
tools: Reduce ARM64 build options

### DIFF
--- a/tools/build_aarch64.sh
+++ b/tools/build_aarch64.sh
@@ -23,7 +23,25 @@ $SRCDIR/configure \
  --disable-tcmalloc \
  --disable-tools \
  --disable-tpm \
- --disable-virtfs \
+ --disable-capstone \
+ --disable-xen \
+ --disable-xen-pci-passthrough \
+ --disable-wdt \
+ --disable-audio \
+ --disable-bluetooth \
+ --disable-usb-redir \
+ --disable-spice \
+ --disable-vnc \
+ --disable-whpx \
+ --disable-hvf \
+ --disable-gtk \
+ --disable-vte \
+ --disable-sdl \
+ --disable-rdma \
+ --disable-vxhs \
+ --disable-vvfat \
+ --disable-parallels \
+ --disable-dmg \
  --enable-attr \
  --enable-cap-ng \
  --enable-fdt \


### PR DESCRIPTION
Reduce the configure flags for the ARM build to match those from the "pure
virt" build script in tools/build_x86_64_virt.sh

Signed-off-by: Rob Bradford <robert.bradford@intel.com>