### PR TITLE
nats: Fix test runner parallel logic

### DIFF
--- a/tools/CI/nats/nemu_amd64_test.go
+++ b/tools/CI/nats/nemu_amd64_test.go
@@ -251,6 +251,14 @@ var clearLinuxOnly = []distro{
 	},
 }
 
+var ubuntuOnly = []distro{
+	{
+		name:      "xenial",
+		image:     xenialDiskImage,
+		cloudInit: cloudInitUbuntu,
+	},
+}
+
 var allMachines = []string{"pc", "q35", "virt"}
 
 var tests = []testConfig{
@@ -263,7 +271,7 @@ var tests = []testConfig{
 	{
 		name:     "Reboot",
 		testFunc: testReboot,
-		distros:  allDistros,
+		distros:  ubuntuOnly,
 		machines: allMachines,
 	},
 	{


### PR DESCRIPTION
Due to the use of goroutines via t.Parallel() the Ubuntu xenial tests were not
running as the value the "test" iterator was pointing to was inconsistent. This
change resolves that problem by using a pointer into the tests array that is
indexed from the original iterator. This will then be bound for the goroutines
and will thus be stable.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>