### PR TITLE
i386: virt: Remove duplicate fields from VirtMachineState

### DIFF
--- a/hw/i386/virt/memory.c
+++ b/hw/i386/virt/memory.c
@@ -42,7 +42,7 @@ MemoryRegion *virt_memory_init(VirtMachineState *vms)
     }
 
     vms->above_4g_mem_size = highmem_size;
-    vms->below_4g_mem_size = lowmem_size;
+    vms->acpi_conf.below_4g_mem_size = lowmem_size;
 
     memory_region_allocate_system_memory(ram, NULL, "virt.ram",
                                          machine->ram_size);

--- a/include/hw/i386/virt.h
+++ b/include/hw/i386/virt.h
@@ -37,15 +37,8 @@ typedef struct {
 
     Notifier machine_done;
 
-    /* NUMA information: */
-    uint64_t numa_nodes;
-    uint64_t *node_mem;
-
     /* ACPI configuration */
-    AcpiConfiguration *acpi_configuration;
-
-    /* Devices and objects */
-    FWCfgState *fw_cfg;
+    AcpiConfiguration acpi_conf;
 
     /* number of CPUs */
     uint16_t boot_cpus;
@@ -54,15 +47,7 @@ typedef struct {
     qemu_irq *gsi;
 
     PCIBus *pci_bus;
-
-    /* ACPI device for hotplug and PM */
-    HotplugHandler *acpi_dev;
-
-    AcpiNVDIMMState acpi_nvdimm_state;
-
-    /* RAM size */
     ram_addr_t above_4g_mem_size;
-    ram_addr_t below_4g_mem_size;
 
     DeviceState *acpi;
 } VirtMachineState;


### PR DESCRIPTION
Remove fields from VirtMachineState that are duplicates of fields that are
stored in AcpiConfiguration. This should prevent bugs that are the result of
field changes not be reflected between the different structs.

For brevity the member on VirtMachineState was also renamed and made an
embedded struct.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>