### PR TITLE
fw_cfg: Use fw_cfg to convey platform information

### DIFF
--- a/hw/i386/virt/virt.c
+++ b/hw/i386/virt/virt.c
@@ -215,8 +215,8 @@ static void virt_machine_state_init(MachineState *machine)
                              "acpi-device", &error_abort);
             
     fw_cfg = fw_cfg_init(machine, smp_cpus, mc->possible_cpu_arch_ids(machine), vms->apic_id_limit);
+    fw_cfg_add_i16(fw_cfg, FW_CFG_MACHINE_ID, X86_VIRT);
     rom_set_fw(fw_cfg);
-
 
     if (machine->device_memory->base) {
         uint64_t *val = g_malloc(sizeof(*val));

--- a/include/hw/i386/pc.h
+++ b/include/hw/i386/pc.h
@@ -19,6 +19,16 @@
 #include "hw/mem/nvdimm.h"
 #include "hw/acpi/acpi_dev_interface.h"
 
+/* fw_cfg machine ids */
+enum {
+    X86_I440FX = 1,
+    X86_Q35,
+    X86_ISAPC,
+    X86_XENFV,
+    X86_XENPV,
+    X86_VIRT,
+};
+
 #define HPET_INTCAP "hpet-intcap"
 
 /**


### PR DESCRIPTION
Firmware (and OS) today uses the device id of the host bridge
as a means of determining the platform on which it is running.
Use fw_cfg instead to send this information. This will allow it
to be decoupled from PCI (as it should be) in the case of a
virtual platform.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>

The initialization is performed outside of `fw_cfg_init` as `fw_cfg_init` 
seems to be a little more generic. Or we can add this as a parameter
to fw_cfg_init.