### PR TITLE
Sync build_x86_64.sh

### DIFF
--- a/hw/watchdog/Makefile.objs
+++ b/hw/watchdog/Makefile.objs
@@ -1,7 +1,9 @@
 common-obj-$(CONFIG_WDT) += watchdog.o
+ifeq ($(CONFIG_WDT),y)
 common-obj-$(CONFIG_WDT_IB6300ESB) += wdt_i6300esb.o
 common-obj-$(CONFIG_WDT_IB700) += wdt_ib700.o
 common-obj-$(CONFIG_WDT_DIAG288) += wdt_diag288.o
 common-obj-$(CONFIG_ASPEED_SOC) += wdt_aspeed.o
-
+else
 common-obj-$(call lnot,$(CONFIG_WDT)) += stub.o
+endif

--- a/hw/watchdog/stub.c
+++ b/hw/watchdog/stub.c
@@ -21,3 +21,7 @@ int select_watchdog(const char *p)
 {
     return 0;
 }
+
+void watchdog_perform_action(void)
+{
+}

--- a/tools/build_x86_64.sh
+++ b/tools/build_x86_64.sh
@@ -24,6 +24,25 @@ $SRCDIR/configure \
  --disable-tools \
  --disable-tpm \
  --disable-virtfs \
+ --disable-tcg \
+ --disable-capstone \
+ --disable-xen \
+ --disable-xen-pci-passthrough \
+ --disable-wdt \
+ --disable-bluetooth \
+ --disable-usb-redir \
+ --disable-spice \
+ --disable-vnc \
+ --disable-whpx \
+ --disable-hvf \
+ --disable-gtk \
+ --disable-vte \
+ --disable-sdl \
+ --disable-rdma \
+ --disable-vxhs \
+ --disable-vvfat \
+ --disable-parallels \
+ --disable-dmg \
  --enable-attr \
  --enable-cap-ng \
  --enable-kvm \


### PR DESCRIPTION
In order to build comparable binaries, we need build_x86_64.sh and
    build_x86_64_virt.sh to be as close as possible.

The only remaining difference between the two scripts is that
    --disable-audio can be selected with the virt machine type but can't
    with the pc one because of ISA requirements.
