### PR TITLE
tools: Build virt binaries into their own folder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ stage ("Builds") {
 				sh "SRCDIR=$WORKSPACE tools/build_x86_64_virt.sh"
 			}
 			stage ('NATS: x86-64 (virt only)') {
-				sh "SRCDIR=$WORKSPACE tools/CI/run_nats.sh -run '.*/.*/virt/.*' -args -nemu-binary-path=$HOME/build-x86_64/x86_64_virt-softmmu/qemu-system-x86_64_virt"
+				sh "SRCDIR=$WORKSPACE tools/CI/run_nats.sh -run '.*/.*/virt/.*' -args -nemu-binary-path=$HOME/build-x86_64_virt/x86_64_virt-softmmu/qemu-system-x86_64_virt"
 			}
 		}
 	})

--- a/tools/build_x86_64_virt.sh
+++ b/tools/build_x86_64_virt.sh
@@ -5,8 +5,8 @@ if [[ "$EXTRA_CFLAGS" == "" ]]; then
     EXTRA_CFLAGS=" -O3 -fno-semantic-interposition -falign-functions=32 -D_FORTIFY_SOURCE=2 -fPIE"
 fi
 
-mkdir -p $HOME/build-x86_64
-pushd $HOME/build-x86_64
+mkdir -p $HOME/build-x86_64_virt
+pushd $HOME/build-x86_64_virt
 make distclean || true
 $SRCDIR/configure \
  --disable-fdt \


### PR DESCRIPTION
So that we can safely generate x86_64 and x86_64_virt binaries without
overlap.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>