### PR TITLE
i386: virt: Fix DIMM hotplug overlap issue

### DIFF
--- a/hw/i386/virt/virt.c
+++ b/hw/i386/virt/virt.c
@@ -593,8 +593,8 @@ static void virt_dimm_plug(HotplugHandler *hotplug_dev,
         align = LINUX_SPARSE_MEMORY_ALIGNMENT;
     }
 
-    free_addr = memory_device_get_free_addr(machine, &machine->device_memory->base,
-                                            align, memory_region_size(mr), &local_err);
+    free_addr = memory_device_get_free_addr(machine, NULL, align,
+                                            memory_region_size(mr), &local_err);
     if (local_err) {
         goto out;
     }


### PR DESCRIPTION
As of QEMU 3.0 the hint parameter to memory_device_get_free_addr() is used to
ask for a DIMM range to be at a specific location in the guest memory. When the
patch to enforce DIMM alignment was originally written this code was purely a
hint. The correct behaviour now is to pass NULL as the hint when requesting a
free address.

The subsequnt call to memory_device_get_free_addr() still takes the explicit
hint which has now been correctly aligned.

Tested by starting a VM with both NVDIMM and DIMM coldplugged on the command
line:

            -device pc-dimm,id=dimm1,memdev=mem0 \
            -object memory-backend-ram,id=mem0,size=1024M \
            -device nvdimm,id=nv0,memdev=mem1 \
            -object memory-backend-file,id=mem1,mem-path=/tmp/nvdimm.img,size=41943040

Signed-off-by: Rob Bradford <robert.bradford@intel.com>