### PR TITLE
DMI: set default values for SMBIOS (If we need DMI)

### DIFF
--- a/hw/i386/fw.c
+++ b/hw/i386/fw.c
@@ -34,7 +34,11 @@ struct hpet_fw_config hpet_cfg = {.count = UINT8_MAX};
 
 static void fw_build_smbios(MachineState *ms, FWCfgState *fw_cfg)
 {
-#if defined(CONFIG_SMBIOS)
+/* TODO: This does not work as expect because CONFIG_SMBIOS=y is
+ * configured inside build/hw/smbios? While fw.o is under x86_64-softmmu/.
+ * To temporarily enable SMBIOS, remove the check for now
+ */
+//#if defined(CONFIG_SMBIOS)
     uint8_t *smbios_tables, *smbios_anchor;
     size_t smbios_tables_len, smbios_anchor_len;
     struct smbios_phys_mem_area *mem_array;
@@ -72,7 +76,7 @@ static void fw_build_smbios(MachineState *ms, FWCfgState *fw_cfg)
         fw_cfg_add_file(fw_cfg, "etc/smbios/smbios-anchor",
                         smbios_anchor, smbios_anchor_len);
     }
-#endif
+//#endif
 }
 
 static void fw_build_feature_control_file(MachineState *ms, FWCfgState *fw_cfg)

--- a/hw/i386/virt/virt.c
+++ b/hw/i386/virt/virt.c
@@ -50,6 +50,7 @@
 #include "kvm_i386.h"
 
 #include "../acpi-build.h"
+#include "hw/smbios/smbios.h"
 
 #define DEFINE_VIRT_MACHINE_LATEST(major, minor, latest) \
     static void virt_##major##_##minor##_object_class_init(ObjectClass *oc, \
@@ -196,6 +197,9 @@ static void virt_machine_state_init(MachineState *machine)
     vms->machine_done.notify = virt_machine_done;
     qemu_add_machine_init_done_notifier(&vms->machine_done);
 
+    /* If enable DMI, then we need set this */
+    smbios_set_defaults("QEMU","VIRTUAL MACHINE (virt)", mc->name,
+                        false, true, SMBIOS_ENTRY_POINT_21);
     /* TODO Add the ram pointer to the QOM */
     virt_memory_init(vms);
     virt_pci_init(vms);


### PR DESCRIPTION
@mcastelino @yangzhon 

If we want to enable DMI, we need firstly set some default values for
SMBIOS, otherwise, smbios_get_tables() will return NULL directly for
the two tables and guest will show as follows.

root@clr-19bebbac82a145bb8c96500c89dbfd8a ~ # dmesg | grep DMI
[    0.000000] DMI not present or invalid.

This makes things as follows, on virt platform. BTW, simiply remove
the CONFIG_SMBIOS check in fw_build_smbios() for now because it does not
give an expective value of CONFIG_SMBIOS.

root@clr-19bebbac82a145bb8c96500c89dbfd8a ~ # dmesg|grep DMI
[    0.000000] DMI: QEMU VIRTUAL MACHINE(virt), BIOS 0.0.0 02/06/2015
