### PR TITLE
vl: Adjust QEMU system binary to indicate this is NEMU

### DIFF
--- a/vl.c
+++ b/vl.c
@@ -1872,7 +1872,7 @@ static void main_loop(void)
 
 static void version(void)
 {
-    printf("QEMU emulator version " QEMU_FULL_VERSION "\n"
+    printf("NEMU (like QEMU) version " QEMU_FULL_VERSION "\n"
            QEMU_COPYRIGHT "\n");
 }
 


### PR DESCRIPTION
For debug reports indicate that this is a NEMU binary not a QEMU one.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>