### PR TITLE
tools: Disable BZIP2 for all builds

### DIFF
--- a/tools/build_aarch64.sh
+++ b/tools/build_aarch64.sh
@@ -15,6 +15,7 @@ $SRCDIR/configure \
  --disable-libssh2 \
  --disable-linux-aio \
  --disable-lzo \
+ --disable-bzip2 \
  --disable-modules \
  --disable-netmap \
  --disable-qom-cast-debug \

--- a/tools/build_x86_64.sh
+++ b/tools/build_x86_64.sh
@@ -15,6 +15,7 @@ $SRCDIR/configure \
  --disable-libssh2 \
  --disable-linux-aio \
  --disable-lzo \
+ --disable-bzip2 \
  --disable-modules \
  --disable-netmap \
  --disable-qom-cast-debug \

--- a/tools/build_x86_64_virt.sh
+++ b/tools/build_x86_64_virt.sh
@@ -15,6 +15,7 @@ $SRCDIR/configure \
  --disable-libssh2 \
  --disable-linux-aio \
  --disable-lzo \
+ --disable-bzip2 \
  --disable-modules \
  --disable-netmap \
  --disable-qom-cast-debug \


### PR DESCRIPTION
It's only needed for the DMG block compression code and we disable DMG
support completely.

Fixes #133

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>