### PR TITLE
tools: Run NATS for all platforms using new ovmf-virt-build branch

### DIFF
--- a/tools/CI/nats/nemu_amd64_test.go
+++ b/tools/CI/nats/nemu_amd64_test.go
@@ -202,7 +202,7 @@ func testCPUHotplug(ctx context.Context, q *qemuTest, t *testing.T) {
 		t.Errorf("Unexpected online cpus: %s", cpusOnlineBefore)
 	}
 
-	err := q.qmp.ExecuteCPUDeviceAdd(ctx, "host-x86_64-cpu", "core2", "2", "0", "0")
+	err := q.qmp.ExecuteCPUDeviceAdd(ctx, "host-x86_64-cpu", "core2", "2", "0", "0", "")
 	if err != nil {
 		t.Errorf("Error hotplugging CPU: %v", err)
 	}

--- a/tools/CI/run_nats.sh
+++ b/tools/CI/run_nats.sh
@@ -3,8 +3,8 @@ set -x
 
 # Set to a specific git revision and repo to test, if empty or unset then will
 # download latest tagged binary
-#OVMF_GIT_REV="2f16693ce32cbe0956ce2dcaa571a32966413855"
-#OVMF_GIT_REPO="https://github.com/intel/ovmf-virt"
+OVMF_GIT_REV="ovmf-virt-build"
+OVMF_GIT_REPO="https://github.com/rbradford/ovmf-virt"
 
 GO_VERSION="1.10.3"
 CLEAR_VERSION=24740


### PR DESCRIPTION
Signed-off-by: Rob Bradford <robert.bradford@intel.com>