### PR TITLE
nats: Update for govmm changes

### DIFF
--- a/tools/CI/nats/nemu_amd64_test.go
+++ b/tools/CI/nats/nemu_amd64_test.go
@@ -202,7 +202,7 @@ func testCPUHotplug(ctx context.Context, q *qemuTest, t *testing.T) {
 		t.Errorf("Unexpected online cpus: %s", cpusOnlineBefore)
 	}
 
-	err := q.qmp.ExecuteCPUDeviceAdd(ctx, "host-x86_64-cpu", "core2", "2", "0", "0")
+	err := q.qmp.ExecuteCPUDeviceAdd(ctx, "host-x86_64-cpu", "core2", "2", "0", "0", "")
 	if err != nil {
 		t.Errorf("Error hotplugging CPU: %v", err)
 	}


### PR DESCRIPTION
The type signature for qmp.ExecuteCPUDeviceAdd() has changed in order to
support supplying a path to a ROM file to use. As we are using OVMF we
can supply an empty romfile.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>