### PR TITLE
i386: virt: Make BIOS region RAM rather than ROM

### DIFF
--- a/hw/i386/virt/memory.c
+++ b/hw/i386/virt/memory.c
@@ -99,7 +99,7 @@ MemoryRegion *virt_memory_init(VirtMachineState *vms)
                                     &machine->device_memory->mr);
     }
 
-    sysfw_firmware_init(system_memory, false);
+    sysfw_firmware_init(system_memory, true);
     
     return ram;
 }


### PR DESCRIPTION
On other machine types, such as Q35, the PAM registers on the PMC can be
used to make this region read/write. However in virt we do not have that
capability. My making the BIOS region read/write we can support simpler
firmware solutions such as qboot.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>