### PR TITLE
Fix the SMM property fetching code path

### DIFF
--- a/hw/i386/pc.c
+++ b/hw/i386/pc.c
@@ -1552,21 +1552,18 @@ static void pc_machine_set_vmport(Object *obj, Visitor *v, const char *name,
     visit_type_OnOffAuto(v, name, &pcms->vmport, errp);
 }
 
-static void pc_machine_get_smm(Object *obj, Visitor *v, const char *name,
-                               void *opaque, Error **errp)
+static int pc_machine_get_smm(Object *obj, Error **errp G_GNUC_UNUSED)
 {
     PCMachineState *pcms = PC_MACHINE(obj);
-    OnOffAuto smm = pcms->smm;
 
-    visit_type_OnOffAuto(v, name, &smm, errp);
+    return pcms->smm;
 }
 
-static void pc_machine_set_smm(Object *obj, Visitor *v, const char *name,
-                               void *opaque, Error **errp)
+static void pc_machine_set_smm(Object *obj, int smm, Error **errp)
 {
     PCMachineState *pcms = PC_MACHINE(obj);
 
-    visit_type_OnOffAuto(v, name, &pcms->smm, errp);
+    pcms->smm = smm;
 }
 
 static bool pc_machine_get_nvdimm(Object *obj, Error **errp)
@@ -1764,9 +1761,10 @@ static void pc_machine_class_init(ObjectClass *oc, void *data)
     object_class_property_set_description(oc, PC_MACHINE_MAX_RAM_BELOW_4G,
         "Maximum ram below the 4G boundary (32bit boundary)", &error_abort);
 
-    object_class_property_add(oc, MACHINE_SMM, "OnOffAuto",
-        pc_machine_get_smm, pc_machine_set_smm,
-        NULL, NULL, &error_abort);
+    object_class_property_add_enum(oc, MACHINE_SMM, "OnOffAuto",
+                                   &OnOffAuto_lookup,
+                                   pc_machine_get_smm, pc_machine_set_smm,
+                                   &error_abort);
     object_class_property_set_description(oc, MACHINE_SMM,
         "Enable SMM (pc & q35)", &error_abort);
 

--- a/target/i386/kvm.c
+++ b/target/i386/kvm.c
@@ -1454,7 +1454,8 @@ int kvm_arch_init(MachineState *ms, KVMState *s)
         Error *prop_err = NULL;
         OnOffAuto smm;
 
-        smm = object_property_get_uint(qdev_get_machine(), MACHINE_SMM, &prop_err);
+        smm = object_property_get_enum(qdev_get_machine(), MACHINE_SMM,
+                                       "OnOffAuto", &prop_err);
         if (!prop_err && is_smm_enabled(smm)) {
                 smram_machine_done.notify = register_smram_listener;
                 qemu_add_machine_init_done_notifier(&smram_machine_done);


### PR DESCRIPTION
Strangely enough, I am seeing KVM emulation errors with HEAD when using the PC machine type, that are due to us not setting the SMRAM notifiers.
This is due to an error in how the PC machine type SMM property is exposed and how it is fetched from the KVM code. This PR fixes both issues and allows me to properly run my PC machine type local tests.