### PR TITLE
Remove isa-bios memory region in virt platform

### DIFF
--- a/hw/i386/pc.c
+++ b/hw/i386/pc.c
@@ -852,7 +852,7 @@ void pc_memory_init(PCMachineState *pcms,
     }
 
     /* Initialize PC system firmware */
-    sysfw_firmware_init(rom_memory, !pcmc->pci_enabled);
+    sysfw_firmware_init(rom_memory, !pcmc->pci_enabled, true);
 
     option_rom_mr = g_malloc(sizeof(*option_rom_mr));
     memory_region_init_ram(option_rom_mr, NULL, "pc.rom", PC_ROM_SIZE,

--- a/hw/i386/virt/memory.c
+++ b/hw/i386/virt/memory.c
@@ -99,7 +99,7 @@ MemoryRegion *virt_memory_init(VirtMachineState *vms)
                                     &machine->device_memory->mr);
     }
 
-    sysfw_firmware_init(system_memory, true);
+    sysfw_firmware_init(system_memory, true, false);
     
     return ram;
 }

--- a/include/hw/i386/fw.h
+++ b/include/hw/i386/fw.h
@@ -27,6 +27,7 @@ enum {
 FWCfgState *fw_cfg_init(MachineState *ms, uint16_t boot_cpus, const CPUArchIdList *cpus, unsigned apic_id_limit);
 
 void sysfw_firmware_init(MemoryRegion *rom_memory,
-                             bool isapc_ram_fw);
+                             bool isapc_ram_fw,
+                             bool isa_bios);
 
 #endif


### PR DESCRIPTION
When i use "info qom-tree" command and find "/isa-bios[0] (qemu:memory-region)" in memory region list.

The isa-bios is not useful in virt platform and i added one bool parameter to check this.

By the way, this patch also fixed another pflash issue in x86.
Memory.c (hw\i386\virt):    sysfw_firmware_init(system_memory, true);

void sysfw_firmware_init(MemoryRegion *rom_memory, bool isapc_ram_fw)
{
    DriveInfo *pflash_drv;

    pflash_drv = drive_get(IF_PFLASH, 0, 0);

    if (isapc_ram_fw || pflash_drv == NULL) {
        /* When a pflash drive is not found, use rom-mode */
        old_pc_system_rom_init(rom_memory, isapc_ram_fw);
        return;
    }

    if (kvm_enabled() && !kvm_readonly_mem_enabled()) {
        /* Older KVM cannot execute from device memory. So, flash memory
         * cannot be used unless the readonly memory kvm capability is present. */
        fprintf(stderr, "qemu: pflash with kvm requires KVM readonly memory support\n");
        exit(1);
    }

    pc_system_flash_init(rom_memory);
}

If we use pflash to flash UEFI bios, the sysfw_firmware_init() still call old_pc_system_rom_init(), the right operation is to call pc_system_flash_init() for pflash. So the cuurent pc_system_flash_init() is not useful.

Please @sameo @rbradford help review this patch, thanks!

