### PR TITLE
nats: Add support for direct kernel boot with OVMF

### DIFF
--- a/tools/CI/nats/nemu_arm64_test.go
+++ b/tools/CI/nats/nemu_arm64_test.go
@@ -130,23 +130,27 @@ var ubuntuArmOnly = []distro{
 }
 
 var armMachine = []string{"virt"}
+
 var tests = []testConfig{
 	{
-		name:     "Shutdown",
-		testFunc: testShutdown,
-		distros:  ubuntuArmOnly,
-		machines: armMachine,
+		name:        "Shutdown",
+		testFunc:    testShutdown,
+		distros:     ubuntuArmOnly,
+		machines:    armMachine,
+		bootMethods: bootLoaderOnly,
 	},
 	{
-		name:     "Reboot",
-		testFunc: testReboot,
-		distros:  ubuntuArmOnly,
-		machines: armMachine,
+		name:        "Reboot",
+		testFunc:    testReboot,
+		distros:     ubuntuArmOnly,
+		machines:    armMachine,
+		bootMethods: bootLoaderOnly,
 	},
 	{
-		name:     "QMPQuit",
-		testFunc: testQMPQuit,
-		distros:  ubuntuArmOnly,
-		machines: armMachine,
+		name:        "QMPQuit",
+		testFunc:    testQMPQuit,
+		distros:     ubuntuArmOnly,
+		machines:    armMachine,
+		bootMethods: bootLoaderOnly,
 	},
 }

--- a/tools/CI/run_nats.sh
+++ b/tools/CI/run_nats.sh
@@ -13,6 +13,8 @@ UBUNTU_IMAGE=xenial-server-cloudimg-amd64-uefi1.img
 WORKLOADS_DIR="$HOME/workloads"
 OVMF="OVMF.fd"
 
+# Matches the kernel for the $CLEAR_IMAGE above
+CLEAR_KERNEL="org.clearlinux.kvm.4.18.16-293"
 
 go_install() {
     export PATH=/usr/local/go/bin:$PATH
@@ -44,6 +46,11 @@ if [ ! -f "$WORKLOADS_DIR"/"$CLEAR_IMAGE" ]; then
     wget -nv https://nemujenkinsstorage.blob.core.windows.net/images/clear-$CLEAR_VERSION-cloud.img.xz ||
     wget -nv https://download.clearlinux.org/releases/$CLEAR_VERSION/clear/clear-$CLEAR_VERSION-cloud.img.xz || exit $?
     unxz clear-$CLEAR_VERSION-cloud.img.xz || exit $?
+fi
+
+
+if [ ! -f "$WORKLOADS_DIR"/"$CLEAR_KERNEL" ]; then
+    wget -nv https://nemujenkinsstorage.blob.core.windows.net/images/$CLEAR_KERNEL
 fi
 
 if [ ! -f "$WORKLOADS_DIR"/"$UBUNTU_IMAGE" ]; then


### PR DESCRIPTION
This change extends NATS to add support for specifying the boot
mechanism (direct or bootloader) and adds supports for booting the Clear
Linux kernel with the corresponding image using OVMF as the BIOS.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>