### PR TITLE
nats: Add support for controlling the boot process

### DIFF
--- a/tools/CI/nats/nemu_arm64_test.go
+++ b/tools/CI/nats/nemu_arm64_test.go
@@ -13,8 +13,12 @@ import (
 	"github.com/intel/govmm/qemu"
 )
 
-func createFlashImages(t *testing.T) (string, string) {
-	firmwareSourceFile, err := os.Open("/usr/share/qemu-efi/QEMU_EFI.fd")
+func getBiosPath() string {
+	return "/usr/share/qemu-efi/QEMU_EFI.fd"
+}
+
+func (q *qemuTest) createFlashImages(t *testing.T) (string, string) {
+	firmwareSourceFile, err := os.Open(q.boot.bios)
 	if err != nil {
 		t.Fatalf("Error creating opening source file for flash image: %v", err)
 	}
@@ -66,7 +70,7 @@ func (q *qemuTest) launchQemu(ctx context.Context, monitorSocketCh chan string, 
 	cloudInitImagePath := q.createCloudInitImage(t)
 	defer os.Remove(cloudInitImagePath)
 
-	flashZeroPath, flashOnePath := createFlashImages(t)
+	flashZeroPath, flashOnePath := q.createFlashImages(t)
 	defer os.Remove(flashZeroPath)
 	defer os.Remove(flashOnePath)
 
@@ -126,6 +130,12 @@ var ubuntuArmOnly = []distro{
 		name:      "xenial",
 		image:     xenialArmDiskImage,
 		cloudInit: cloudInitUbuntu,
+		bootConfigs: []bootConfig{
+			{
+				name: bootMethodOVMF,
+				bios: getBiosPath(),
+			},
+		},
 	},
 }
 

--- a/tools/CI/run_nats.sh
+++ b/tools/CI/run_nats.sh
@@ -13,6 +13,8 @@ UBUNTU_IMAGE=xenial-server-cloudimg-amd64-uefi1.img
 WORKLOADS_DIR="$HOME/workloads"
 OVMF="OVMF.fd"
 
+# Matches the kernel for the $CLEAR_IMAGE above
+CLEAR_KERNEL="org.clearlinux.kvm.4.18.16-293"
 
 go_install() {
     export PATH=/usr/local/go/bin:$PATH
@@ -44,6 +46,11 @@ if [ ! -f "$WORKLOADS_DIR"/"$CLEAR_IMAGE" ]; then
     wget -nv https://nemujenkinsstorage.blob.core.windows.net/images/clear-$CLEAR_VERSION-cloud.img.xz ||
     wget -nv https://download.clearlinux.org/releases/$CLEAR_VERSION/clear/clear-$CLEAR_VERSION-cloud.img.xz || exit $?
     unxz clear-$CLEAR_VERSION-cloud.img.xz || exit $?
+fi
+
+
+if [ ! -f "$WORKLOADS_DIR"/"$CLEAR_KERNEL" ]; then
+    wget -nv https://nemujenkinsstorage.blob.core.windows.net/images/$CLEAR_KERNEL
 fi
 
 if [ ! -f "$WORKLOADS_DIR"/"$UBUNTU_IMAGE" ]; then


### PR DESCRIPTION
To the distro struct, add a slice of bootConfigs which can be used to
control the boot including BIOS path and optionally kernel path and
kernel command line.

The contents of this struct is then used when constructing the QEMU
command line.

Further add support for direct kernel boot when using Clear Linux.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>