### PR TITLE
hw: pci: Use assigned PCI ID for virt

### DIFF
--- a/hw/pci-host/pci_lite.c
+++ b/hw/pci-host/pci_lite.c
@@ -284,9 +284,8 @@ static void pci_lite_device_class_init(ObjectClass *klass, void *data)
     k->class_id = PCI_CLASS_BRIDGE_HOST;
     dc->desc = "Host bridge";
 
-    // TODO: Use different one to GPEX?
-    k->vendor_id = PCI_VENDOR_ID_REDHAT;
-    k->device_id = PCI_DEVICE_ID_REDHAT_PCIE_HOST;
+    k->vendor_id = PCI_VENDOR_ID_INTEL;
+    k->device_id = PCI_DEVICE_ID_INTEL_VIRT_PCIE_HOST;
     k->revision = 0;
 
     /*

--- a/include/hw/pci/pci_ids.h
+++ b/include/hw/pci/pci_ids.h
@@ -257,6 +257,8 @@
 
 #define PCI_DEVICE_ID_INTEL_Q35_MCH      0x29c0
 
+#define PCI_DEVICE_ID_INTEL_VIRT_PCIE_HOST 0x0d57
+
 #define PCI_VENDOR_ID_XEN                0x5853
 #define PCI_DEVICE_ID_XEN_PLATFORM       0x0001
 


### PR DESCRIPTION
A new PCI ID has been assigned for the PCI host bridge used with virt.
The appropriate change is also necessary for any firmware in use, e.g.
OVMF.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>