### PR TITLE
Revert "nats: Temporarily disable CPU hotplug test on virt"

### DIFF
--- a/tools/CI/nats/nemu_amd64_test.go
+++ b/tools/CI/nats/nemu_amd64_test.go
@@ -374,8 +374,7 @@ var tests = []testConfig{
 		name:     "CPUHotplug",
 		testFunc: testCPUHotplug,
 		distros:  clearLinuxOnly,
-		// https://github.com/intel/nemu/issues/174
-		machines: []string{"pc", "q35"},
+		machines: allMachines,
 	},
 	{
 		name:     "MemoryHotplug",


### PR DESCRIPTION
This reverts commit d4a2edcd1b4ca61e6c56c73d328e88a0b59da1d6.