### PR TITLE
sysfw: Bump BIOS region size

### DIFF
--- a/hw/i386/sysfw.c
+++ b/hw/i386/sysfw.c
@@ -222,7 +222,7 @@ static void old_pc_system_rom_init(MemoryRegion *rom_memory, bool isapc_ram_fw)
     g_free(filename);
 
     /* map the last 128KB of the BIOS in ISA space */
-    isa_bios_size = MIN(bios_size, 128 * KiB);
+    isa_bios_size = MIN(bios_size, 256 * KiB);
     isa_bios = g_malloc(sizeof(*isa_bios));
     memory_region_init_alias(isa_bios, NULL, "isa-bios", bios,
                              bios_size - isa_bios_size, isa_bios_size);


### PR DESCRIPTION
The default seabios image is greater than 128KiB so ensure that the
mapping can handle it.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>