### PR TITLE
i386: virt: Add option rom for direct kernel boot

### DIFF
--- a/hw/i386/virt/virt.c
+++ b/hw/i386/virt/virt.c
@@ -239,7 +239,12 @@ static void virt_machine_state_init(MachineState *machine)
     acpi_conf_virt_init(machine);
 
     if (linux_boot) {
+        vms->acpi_conf.linuxboot_dma_enabled = true;
         load_linux(MACHINE(vms), &vms->acpi_conf, fw_cfg);
+
+        for (i = 0; i < nb_option_roms; i++) {
+            rom_add_option(option_rom[i].name, option_rom[i].bootindex);
+        }
     }
 }
 


### PR DESCRIPTION
When using Seabios, direct kernel boot is implemented as an option rom
provided by QEMU. Enable the addition of "linuxboot_dma.bin" by setting
the appropriate flag on AcpiConfiguration. This will then cause
load_linux() to add the appropriate option rom to the global variables
but they must be explicitly installed by the macchine.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>