### PR TITLE
nats: Re-enable Reboot test for Clear Linux

### DIFF
--- a/tools/CI/nats/nemu_amd64_test.go
+++ b/tools/CI/nats/nemu_amd64_test.go
@@ -355,7 +355,7 @@ var tests = []testConfig{
 	{
 		name:     "Reboot",
 		testFunc: testReboot,
-		distros:  ubuntuOnly,
+		distros:  allDistros,
 		machines: allMachines,
 	},
 	{


### PR DESCRIPTION
This test was flaky in the past but we've made several NATS related
changes recently which may mean this test is no longer flaky.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>