### PR TITLE
virtio-pci: Correctly expose vector count for virtio-rng-pci

### DIFF
--- a/hw/virtio/virtio-pci.c
+++ b/hw/virtio/virtio-pci.c
@@ -2489,6 +2489,11 @@ static void virtio_rng_pci_realize(VirtIOPCIProxy *vpci_dev, Error **errp)
                              NULL);
 }
 
+static Property virtio_rng_pci_properties[] = {
+    DEFINE_PROP_UINT32("vectors", VirtIOPCIProxy, nvectors, 2),
+    DEFINE_PROP_END_OF_LIST(),
+};
+
 static void virtio_rng_pci_class_init(ObjectClass *klass, void *data)
 {
     DeviceClass *dc = DEVICE_CLASS(klass);
@@ -2498,6 +2503,7 @@ static void virtio_rng_pci_class_init(ObjectClass *klass, void *data)
     k->realize = virtio_rng_pci_realize;
     set_bit(DEVICE_CATEGORY_MISC, dc->categories);
 
+    dc->props = virtio_rng_pci_properties;
     pcidev_k->vendor_id = PCI_VENDOR_ID_REDHAT_QUMRANET;
     pcidev_k->device_id = PCI_DEVICE_ID_VIRTIO_RNG;
     pcidev_k->revision = VIRTIO_PCI_ABI_VERSION;


### PR DESCRIPTION
The vector count should be  1 + the number of virtqueues which is one
for virtio-rng. The other PCI devices correctly define this property and
default value. This will then enable the use of MSI-X which prevents the
kernel from falling back to legacy interrupts which we do not support.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>