### PR TITLE
build: Enable seccomp support

### DIFF
--- a/tools/build_aarch64.sh
+++ b/tools/build_aarch64.sh
@@ -19,7 +19,6 @@ $SRCDIR/configure \
  --disable-modules \
  --disable-netmap \
  --disable-qom-cast-debug \
- --disable-seccomp \
  --disable-snappy \
  --disable-tcmalloc \
  --disable-tools \
@@ -51,6 +50,7 @@ $SRCDIR/configure \
  --enable-fdt \
  --enable-kvm \
  --enable-rbd \
+ --enable-seccomp \
  --enable-vhost-crypto \
  --enable-vhost-net \
  --enable-vhost-scsi \

--- a/tools/build_x86_64.sh
+++ b/tools/build_x86_64.sh
@@ -19,7 +19,6 @@ $SRCDIR/configure \
  --disable-modules \
  --disable-netmap \
  --disable-qom-cast-debug \
- --disable-seccomp \
  --disable-snappy \
  --disable-tcmalloc \
  --disable-tools \
@@ -50,6 +49,7 @@ $SRCDIR/configure \
  --enable-cap-ng \
  --enable-kvm \
  --enable-rbd \
+ --enable-seccomp \
  --enable-vhost-crypto \
  --enable-vhost-net \
  --enable-vhost-scsi \

--- a/tools/build_x86_64_virt.sh
+++ b/tools/build_x86_64_virt.sh
@@ -19,7 +19,6 @@ $SRCDIR/configure \
  --disable-modules \
  --disable-netmap \
  --disable-qom-cast-debug \
- --disable-seccomp \
  --disable-snappy \
  --disable-tcmalloc \
  --disable-tools \
@@ -51,6 +50,7 @@ $SRCDIR/configure \
  --enable-cap-ng \
  --enable-kvm \
  --enable-rbd \
+ --enable-seccomp \
  --enable-vhost-crypto \
  --enable-vhost-net \
  --enable-vhost-scsi \


### PR DESCRIPTION
Enable seccomp support for enhanced security.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>