### PR TITLE
build: Change releasing mechanism

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ stage ("Builds") {
 				sh "SRCDIR=$WORKSPACE tools/CI/run_nats_aarch64.sh"
 			}
 			stage ('Upload binary: aarch64') {
-				if (env.BRANCH_NAME.contains("releases/candidate")) {
+				if (env.TAG_NAME != null) {
 					sh "cp $HOME/build-aarch64/aarch64-softmmu/qemu-system-aarch64 ."
 					azureUpload storageCredentialId: 'nemu-jenkins-storage-account', 
 						filesPath: "qemu-system-aarch64",
@@ -72,7 +72,7 @@ stage ("Builds") {
 				sh "SRCDIR=$WORKSPACE tools/CI/run_nats.sh -run '.*/.*/virt/.*' -args -nemu-binary-path=$HOME/build-x86_64_virt/x86_64_virt-softmmu/qemu-system-x86_64_virt"
 			}
 			stage ('Upload binary: x86-64 (virt only)') {
-				if (env.BRANCH_NAME.contains("releases/candidate")) {
+				if (env.TAG_NAME != null) {
 					sh "cp $HOME/build-x86_64_virt/x86_64_virt-softmmu/qemu-system-x86_64_virt ."
 					azureUpload storageCredentialId: 'nemu-jenkins-storage-account', 
 						filesPath: "qemu-system-x86_64_virt",
@@ -125,7 +125,7 @@ stage ("Analyse") {
 }
 
 stage ("Release") {
-	if (env.BRANCH_NAME.contains("releases/candidate")) { 
+	if (env.TAG_NAME != null) { 
 		node ('master'){
 			stage ('Checkout: analyse') {
 					checkout scm
@@ -142,7 +142,7 @@ stage ("Release") {
 					usernameVariable: 'GITHUB_USERNAME',
 					passwordVariable: 'GITHUB_PASSWORD'
 				]]) {
-					sh "hub release create -m \"Release \$(date +%Y-%m-%d)\" -a qemu-system-x86_64_virt -a qemu-system-aarch64 release-`date +%Y-%m-%d`" 
+					sh "hub release create -p -d -m \"${env.TAG_NAME}\" -a qemu-system-x86_64_virt -a qemu-system-aarch64 ${env.TAG_NAME}" 
 				}
 			}
 		}


### PR DESCRIPTION
A draft release will be created now from any tag including uploading any
binary artifacts. This release can then be "undrafted" to expose it to
the public.

This allows making releases with any names from any branch.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>