### PR TITLE
virt: memory: Mark BIOS as read-only

### DIFF
--- a/hw/i386/virt/memory.c
+++ b/hw/i386/virt/memory.c
@@ -97,7 +97,7 @@ MemoryRegion *virt_memory_init(VirtMachineState *vms)
                                     &machine->device_memory->mr);
     }
 
-    pc_system_rom_init(system_memory, true);
+    pc_system_rom_init(system_memory, false);
 
     return ram;
 }


### PR DESCRIPTION
If the bios region is not marked as read-only then vhost backend will
attempt to use the regions for vhost but then reject it as the page size
has changed.

Fixes: #233

Signed-off-by: Rob Bradford <robert.bradford@intel.com>