### PR TITLE
vhost & sysfw: Mark BIOS regions as "vhost_ignore"

### DIFF
--- a/hw/i386/sysfw.c
+++ b/hw/i386/sysfw.c
@@ -65,6 +65,7 @@ void pc_system_rom_init(MemoryRegion *rom_memory, bool rw_fw)
     if (!rw_fw) {
         memory_region_set_readonly(bios, true);
     }
+    bios->vhost_ignore = true;
     ret = rom_add_file_fixed(bios_name, (uint32_t)(-bios_size), -1);
     if (ret != 0) {
     bios_error:
@@ -85,6 +86,7 @@ void pc_system_rom_init(MemoryRegion *rom_memory, bool rw_fw)
     if (!rw_fw) {
         memory_region_set_readonly(isa_bios, true);
     }
+    isa_bios->vhost_ignore = true;
 
     /* map all the bios at the top of memory */
     memory_region_add_subregion(rom_memory,

--- a/hw/virtio/vhost.c
+++ b/hw/virtio/vhost.c
@@ -392,7 +392,8 @@ static bool vhost_section(struct vhost_dev *dev, MemoryRegionSection *section)
     bool log_dirty = memory_region_get_dirty_log_mask(section->mr) &
                      ~(1 << DIRTY_MEMORY_MIGRATION);
     result = memory_region_is_ram(section->mr) &&
-        !memory_region_is_rom(section->mr);
+        !memory_region_is_rom(section->mr) &&
+        !section->mr->vhost_ignore;
 
     /* Vhost doesn't handle any block which is doing dirty-tracking other
      * than migration; this typically fires on VGA areas.

--- a/include/exec/memory.h
+++ b/include/exec/memory.h
@@ -385,6 +385,7 @@ struct MemoryRegion {
     const char *name;
     unsigned ioeventfd_nb;
     MemoryRegionIoeventfd *ioeventfds;
+    bool vhost_ignore;
 };
 
 struct IOMMUMemoryRegion {


### PR DESCRIPTION
Without this change vhost will try to use the memory regions created by
pc_system_rom_init() which have a page size that does not match the
system memory (they differ as the latter is backed by an fd which
determines the page size.)

The vhost code normally rejects BIOS regions as they are marked R/O
however we cannot do that with the virt platform as we lack a PAM to
have the regions remapped to R/W for some firmwares (i.e. Seabios) to
use whilst booting.

Instead workaround this issue by adding a member to the region to
indicate that vhost should ignore this region.

Fixes: #233

Signed-off-by: Rob Bradford <robert.bradford@intel.com>