### PR TITLE
Fix heap overflow in ip_reass on big packet input

### DIFF
--- a/slirp/src/ip_input.c
+++ b/slirp/src/ip_input.c
@@ -331,6 +331,8 @@ insert:
     q = fp->frag_link.next;
 	m = dtom(slirp, q);
 
+        int was_ext = m->m_flags & M_EXT;
+
 	q = (struct ipasfrag *) q->ipf_next;
 	while (q != (struct ipasfrag*)&fp->frag_link) {
 	  struct mbuf *t = dtom(slirp, q);
@@ -353,7 +355,7 @@ insert:
 	 * the old buffer (in the mbuf), so we must point ip
 	 * into the new buffer.
 	 */
-	if (m->m_flags & M_EXT) {
+        if (!was_ext && m->m_flags & M_EXT) {
 	  int delta = (char *)q - m->m_dat;
 	  q = (struct ipasfrag *)(m->m_ext + delta);
 	}


### PR DESCRIPTION
When the first fragment does not fit in the preallocated buffer, q will
already be pointing to the ext buffer, so we mustn't try to update it.

Fixes CVE-2019-14378

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>
Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>